### PR TITLE
fix: Submit form only when submitIfValid and isValid are true

### DIFF
--- a/src/form.tsx
+++ b/src/form.tsx
@@ -66,8 +66,8 @@ export function Form<T>({
       Object.keys(context.current)
         .map(key => context.current?.[key]?.validate?.())
         .filter(i => i !== true).length === 0
-    setSubmitted(true)
-    if (!submitIfValid || isValid) {
+    if (submitIfValid && isValid) {
+      setSubmitted(true)
       onSubmit?.({ state: state.current, isValid })
     }
   }, [onSubmit, submitIfValid])


### PR DESCRIPTION
fixes: #1 

### Description

- Will update the condition to submit form only when both `submitIfValid` and `isValid` are true.